### PR TITLE
修复不能通过插件页面访问插件设置的问题

### DIFF
--- a/editormd_class.php
+++ b/editormd_class.php
@@ -39,7 +39,7 @@ class editormd {
 	 */
 	function jetpack_markdown_settings_link( $actions ) {
 		return array_merge(
-			array( 'settings' => sprintf( '<a href="%s">%s</a>', 'options-general.php?page=WP-Editor.MD%2Feditormd_options.php', __( 'Settings', 'jetpack' ) ) ),
+			array( 'settings' => sprintf( '<a href="%s">%s</a>', 'options-general.php?page=' . plugin_basename( __DIR__ . '/editormd_options.php' ), __( 'Settings', 'jetpack' ) ) ),
 			$actions
 		);
 	}


### PR DESCRIPTION
如果从 WordPress 下载插件，插件的目录是 `wp-editormd`，代码中直接写死目录了。。。