### PR TITLE
Support footnote and anchor in XSS filter.

### DIFF
--- a/Jetpack/markdown/xsshtml.class.php
+++ b/Jetpack/markdown/xsshtml.class.php
@@ -156,6 +156,8 @@ class XssHtml {
 			return $url;
 		} if ( preg_match( '#^sftp?://.+#is', $url ) ) {
 			return $url;
+		} else if ( preg_match( '/^#.+/is', $url ) ) { // footnote or anchor
+      			return $url;
 		} else {
 			return 'http://' . $url;
 		}
@@ -233,7 +235,9 @@ class XssHtml {
 		$href = $this->__get_link( $node, 'href' );
 
 		$this->__setAttr( $node, 'href', $href );
-		$this->__set_default_attr( $node, 'target', '_blank' );
+		if (substr($href, 0, 1) != '#') { // not footnote or anchor
+			$this->__set_default_attr( $node, 'target', '_blank' );
+		}
 	}
 
 	private function __node_embed( $node ) {


### PR DESCRIPTION
現行的 XSS filter 會屏蔽掉錨及 Makrdown 產生的 footnote 跳轉連結，這個 patch 讓 "#" 開頭的連結（錨）不被 XSS filter 修改，並同時避免錨被加上 `target="_blank"`。

// 但是可能要考慮評論中的 markdown 該不該支持錨操作