### PR TITLE
修复与WordPress5.3版本不兼容的问题

### DIFF
--- a/src/Utils/Settings.php
+++ b/src/Utils/Settings.php
@@ -88,7 +88,7 @@ class Settings {
 		wp_add_inline_script(
 			'code-editor',
 			sprintf(
-				'jQuery( function() { $("#editor_mermaid\\\\[mermaid_config\\\\]").length !== 0 ? wp.codeEditor.initialize( "editor_mermaid\\\\[mermaid_config\\\\]", %s ) : ""; } );',
+				'jQuery( function() { jQuery("#editor_mermaid\\\\[mermaid_config\\\\]").length !== 0 ? wp.codeEditor.initialize( "editor_mermaid\\\\[mermaid_config\\\\]", %s ) : ""; } );',
 				wp_json_encode( $settings )
 			)
 		);


### PR DESCRIPTION
WordPress5.3版本jQuery不再暴露`$`方法，导致该软件在后台出现报错，编辑器无法显示，提示`$ is not a function`。

全局查找包含`$(...)`的引用发现`src/Utils/Settings.php`文件的第91行依旧存在对`$`的引用，且上下文中并未将`jQuery`转换为`$`，将其修改为`jQuery`后功能恢复正常。